### PR TITLE
Parse timestamp strings in heuristicate-types, issue #14

### DIFF
--- a/src/properties.lisp
+++ b/src/properties.lisp
@@ -10,9 +10,13 @@ Often when reading in a data set, the types will be inconsistent in a variable. 
   (let ((name (name df)))
     (map nil #'(lambda (key)
 		 (let* ((data     (column df key))
-			(col-type (column-type data))
-			(sym (find-symbol (symbol-name key) (find-package name))))
-		   (setf (get sym :type) col-type)))
+				(col-type (column-type data))
+				(sym (find-symbol (symbol-name key) (find-package name))))
+		   (setf (get sym :type) col-type)
+		   ;; If a column is :temporal, replace strings in it with timestamps.
+		   ;; If local-time fails to parse a value then signal an error without corrupting the dataframe.
+		   (when (eql col-type :temporal)
+			 (setf (column df key) (map 'vector #'local-time:parse-timestring data)))))
 	 (keys df))))
 
 (defun set-properties (df property prop-values)

--- a/src/utils.lisp
+++ b/src/utils.lisp
@@ -9,6 +9,17 @@
 ;;; cl:type-of is under-constrained and returns implementation
 ;;; specific results, so we use our own version
 ;;; See: https://www.cs.cmu.edu/Groups/AI/html/cltl/clm/node53.html
+
+
+(defun timestamp-string-p (string)
+  "Return T if STRING can be parsed as a timestamp by LOCAL-TIME."
+  (and (stringp string)
+       (when (local-time:parse-timestring string :fail-on-error nil)
+		 t)))
+
+(deftype timestamp-string ()
+  '(satisfies timestamp-string-p))
+
 (defun get-type (x)
   "Return the most specific type symbol for x"
   (typecase x
@@ -22,6 +33,7 @@
     ;; (rational 'cl:rational)		;SBCL doesn't recognise this return type
     ;; (real    'real)			;SBCL doesn't recognise this return type
 
+	(timestamp-string 'temporal)
     (simple-string 'simple-string)
     (string 'string)
 
@@ -54,6 +66,7 @@
 	  ((member 'fixnum  type-list) :fixnum)
 	  ((member 'integer type-list) :integer)
 	  ((member 'string  type-list) :string)
+	  ((member 'temporal  type-list) :temporal)
 	  ((member 'bit     type-list) :bit)
 	  ((member 'symbol  type-list) :symbol)
 	  (t 'string ))))


### PR DESCRIPTION
Hello,

This is a draft implementation of the behavior proposed in issue #14. Now `heuristicate-types` replaces timestamp strings with `timestamp` objects using `local-time`.

I've only recently started studying lisp-stat and may miss some details. Please let me know if my approach to this task is correct. I'll be glad to hear any feedback, fix the issues and do all the work necessary to merge this feature.

---
Alexander Kuzmin